### PR TITLE
Fix 502 error after login and timeout

### DIFF
--- a/oauth_handler/handler.py
+++ b/oauth_handler/handler.py
@@ -178,6 +178,9 @@ class OAuthHandler(BaseHTTPRequestHandler):
                 state = parsed_query.get('state', [''])
                 if not check_state(state[0]):
                     logger.warn("State is not correct in the response during OAuth2 authentication")
+                    self.send_response(302)
+                    self.send_header('Location', '/')
+                    self.end_headers()
                     return False
                 code = parsed_query.get('code', [''])
                 token = oauth_http_client.get_token(code[0])

--- a/oauth_handler/oauth_connector.py
+++ b/oauth_handler/oauth_connector.py
@@ -43,6 +43,7 @@ class OAuthHTTPClient:
 
     def login(self):
         client = WebApplicationClient(self.params.client_id)
+        oauth_session_data.clear()
         oauth_session_data['state'] = secrets.token_urlsafe(16)
 
         url_to_redirect = client.prepare_request_uri(


### PR DESCRIPTION
Problem:
Some times there is 502 bad gateway error shown in browser immediately after login and also after timeout. Error is inconsistent and occurs randomly at certain times. 

Solution:
Problem occurs when there is a mismatch of `state` parameter in Oauth request. This fix clears old state parameter on fresh login and also redirects to home page to re-initiate login when such problem occurs.