### PR TITLE
ci: add functional pull request gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,81 +1,197 @@
 name: Build Artifacts
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
 on:
   release:
     types: [created]
   push:
     branches:
-    - '**'
-    paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - main
   pull_request:
     branches:
-    - '**'
-    paths-ignore:
-    - '.github/**'
-    - 'docs/**'
-    - 'CODE-OF-CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'README.md'
-    - 'SECURITY.md'
+      - "**"
+
+permissions: {}
 
 concurrency:
-  # On main/release, we don't want any jobs cancelled so the sha is used to name the group
-  # On PR branches, we cancel the job if new commits are pushed
-  # More info: https://stackoverflow.com/a/68422069/253468
-  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('build-pr-{0}', github.ref) || format('build-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  multiplatform_build:
-    # Build PRs only if the event comes from Dependabot. Skip branch pushes
-    if: github.event.pull_request.user.login != 'renovate[bot]' || github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        component:
-        - name: qubership-graylog-auth-proxy
-          file: Dockerfile
-          context: ""
+  changes:
+    name: Detect relevant changes
     runs-on: ubuntu-latest
-    name: ${{ matrix.component.name }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      tests: ${{ github.event_name == 'release' || steps.filter.outputs.tests }}
+      container: ${{ github.event_name == 'release' || steps.filter.outputs.container }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7.0.0
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v6
-      with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-    - name: Login to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push
-      uses: docker/build-push-action@v7
-      with:
-        no-cache: true
-        context: ${{ matrix.component.context }}
-        file: ${{ matrix.component.file }}
-        platforms: linux/amd64,linux/arm64
-        # See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#fetching-metadata-about-a-pull-request
-        push: ${{ github.event_name != 'pull_request' && github.actor != 'renovate[bot]' }}
-        provenance: false
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Checkout push
+        if: github.event_name == 'push'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 100
+          persist-credentials: false
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name != 'release'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            tests:
+              - '.github/workflows/build.yml'
+              - 'Dockerfile'
+              - 'Makefile'
+              - 'pytest.ini'
+              - 'requirements.txt'
+              - 'test-requirements.txt'
+              - 'src/**'
+              - 'tests/**'
+            container:
+              - '.github/workflows/build.yml'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'src/**'
+
+  test:
+    name: Run Python tests
+    needs: changes
+    if: needs.changes.outputs.tests == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: test-requirements.txt
+      - name: Run tests
+        run: make test
+
+  multiplatform_build:
+    name: Build container image
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.container == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: false
+
+  publish_image:
+    name: Publish container image
+    needs: [changes, test]
+    if: >-
+      (github.event_name == 'release' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')) &&
+      needs.changes.result == 'success' &&
+      needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Create image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/qubership-graylog-auth-proxy
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          no-cache: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  ci_gate:
+    name: Graylog Auth Proxy CI Gate
+    needs: [changes, test, multiplatform_build]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify required jobs
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TESTS_REQUIRED: ${{ needs.changes.outputs.tests }}
+          TEST_RESULT: ${{ needs.test.result }}
+          CONTAINER_REQUIRED: ${{ needs.changes.outputs.container }}
+          CONTAINER_RESULT: ${{ needs.multiplatform_build.result }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [[ "$TESTS_REQUIRED" == "true" && "$TEST_RESULT" != "success" ]]; then
+            echo "Python tests were required but did not succeed: $TEST_RESULT"
+            exit 1
+          fi
+          if [[ "$TESTS_REQUIRED" != "true" && "$TEST_RESULT" != "skipped" ]]; then
+            echo "Python tests were not required but had an unexpected result: $TEST_RESULT"
+            exit 1
+          fi
+
+          if [[ "$CONTAINER_REQUIRED" == "true" && "$CONTAINER_RESULT" != "success" ]]; then
+            echo "The container build was required but did not succeed: $CONTAINER_RESULT"
+            exit 1
+          fi
+          if [[ "$CONTAINER_REQUIRED" != "true" && "$CONTAINER_RESULT" != "skipped" ]]; then
+            echo "The container build was not required but had an unexpected result: $CONTAINER_RESULT"
+            exit 1
+          fi


### PR DESCRIPTION
## Why

The existing build workflow did not run the repository's pytest suite and could omit its only functional check for documentation or workflow-only pull requests. It also mixed pull-request validation with the authenticated image publication path, which made it unsuitable as a required gate for Renovate automerge.

## What changed

- Run change detection for every pull request and push to `main`, while treating release events as unconditionally relevant and avoiding duplicate feature-branch push runs.
- Run `make test` for Python, dependency, test, build, and workflow changes.
- Build the real multi-platform container for relevant pull requests without logging in or publishing.
- Add the always-present, fail-closed `Graylog Auth Proxy CI Gate` check; irrelevant pull requests skip expensive jobs but still receive a successful gate.
- Keep package write permission and GHCR login isolated to release events and relevant pushes to `main`; feature-branch pushes and pull requests cannot publish.
- Pin all actions to verified commit SHAs and remove obsolete Dependabot-specific conditions and comments.

## How to verify

- `make test`
- `actionlint .github/workflows/build.yml`
- `docker build --check .`
- `docker build -t qubership-graylog-auth-proxy:ci-gate-105 .`
- Confirm that a workflow-only PR runs tests, a real container build, and `Graylog Auth Proxy CI Gate`.
- Confirm that an irrelevant documentation-only PR skips tests and the container build but still passes `Graylog Auth Proxy CI Gate`.

Three independent reviews covered path selection, gate truth-table behavior, fork permissions, action pins, and push/release semantics. No blocking findings remain.

Closes #105
